### PR TITLE
Remove margin when plotting

### DIFF
--- a/R/qrcode_gen.R
+++ b/R/qrcode_gen.R
@@ -48,7 +48,7 @@ qrcode_gen <- function(dataString,ErrorCorrectionLevel='L',dataOutput = FALSE, p
     #apply mask
     dataMasked <- qrMask(data,qrInfo,mask)
     if(plotQRcode){
-      heatmap(dataMasked[nrow(dataMasked):1,],Rowv = NA, Colv = NA,scale="none",col=c(wColor,bColor),labRow ='',labCol = '')
+      heatmap(dataMasked[nrow(dataMasked):1,],Rowv = NA, Colv = NA,scale="none",col=c(wColor,bColor),labRow ='',labCol = '',margins = 0)
     }
     if(dataOutput){
       return(dataMasked)


### PR DESCRIPTION
Added argument "margins = 0" to heatmap function

---

Thankyou for your efforts in creating this package. When plotting the qrcode, there is a white margin below and to the right of the image. At least for my purposes, this is unwanted and can be removed using the "margins = 0" argument of heatmap.
