### PR TITLE
Trim whitespace around plot

### DIFF
--- a/R/qrcode_gen.R
+++ b/R/qrcode_gen.R
@@ -48,7 +48,7 @@ qrcode_gen <- function(dataString,ErrorCorrectionLevel='L',dataOutput = FALSE, p
     #apply mask
     dataMasked <- qrMask(data,qrInfo,mask)
     if(plotQRcode){
-      heatmap(dataMasked[nrow(dataMasked):1,],Rowv = NA, Colv = NA,scale="none",col=c(wColor,bColor),labRow ='',labCol = '',margins = 0)
+      heatmap(dataMasked[nrow(dataMasked):1,],Rowv = NA, Colv = NA,scale="none",col=c(wColor,bColor),labRow ='',labCol = '',margins = c(0.5, 0.5))
     }
     if(dataOutput){
       return(dataMasked)

--- a/R/qrcode_gen.R
+++ b/R/qrcode_gen.R
@@ -48,7 +48,7 @@ qrcode_gen <- function(dataString,ErrorCorrectionLevel='L',dataOutput = FALSE, p
     #apply mask
     dataMasked <- qrMask(data,qrInfo,mask)
     if(plotQRcode){
-      heatmap(dataMasked[nrow(dataMasked):1,],Rowv = NA, Colv = NA,scale="none",col=c(wColor,bColor),labRow ='',labCol = '')
+      heatmap(dataMasked[nrow(dataMasked):1,],Rowv = NA, Colv = NA,scale="none",col=c(wColor,bColor),labRow ='',labCol = '',margins = 0)
     }
     if(dataOutput){
       return(dataMasked)


### PR DESCRIPTION
Thankyou for your efforts in creating this package.

At least for my purposes, there is currently too much whitespace below and to the right of the qrcode plot. By adding the argument "margins = c(0.5, 0.5)" to the heatmap function, we can achieve a small and equal amount of whitespace on all sides of the plot.
